### PR TITLE
Delete CNAME to allow new website repo to link to microelastic.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-microelastic.com


### PR DESCRIPTION
This change allows the microelastic/website repository to function as the source for microelastic.com. 